### PR TITLE
doc: mark toctree :hidden:, remove search/modindex

### DIFF
--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -3,6 +3,7 @@ Base64
 
 .. toctree::
    :maxdepth: 3
+   :hidden:
 
    usage
    reference
@@ -15,8 +16,6 @@ defined in `RFC 1521 <https://datatracker.ietf.org/doc/html/rfc1521>`__
 by Borensten & Freed, September 1993.
 
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
Package doc toctrees need to be marked `:hidden:` or their ToC will be included in the main opendylan.org ToC. That's not a problem, per se, but it also means (apparently) that the title of the document is included in the opendylan.org ToC, which I don't want; I want each package's ToC entry to be only the name of the package, for consistency.

Note that if the `:hidden:` toctree is the top-level toctree, the `:hidden:` annotation is ignored (at least by the Furo theme). So the toctree is still displayed in the left nav when the package's doc is deployed by itself, outside of opendylan.org.

Also removing the `modindex`, which is Python specific, and `search` which is not needed with the Furo theme.